### PR TITLE
resolved namespace problem

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,8 @@
 
 
 I test it with :
-Terraform v1.1.2
-provider helm v2.5.1
+Terraform v1.5.4
+provider helm v3.12.2
 provider hashicorp/kubernetes v2.11.0
 
 - Change adminPassword in values.yaml

--- a/main.tf
+++ b/main.tf
@@ -1,3 +1,9 @@
+resource "kubernetes_namespace" "kube_namespace" {
+  metadata {
+    name     = "monitoring"
+  }
+}
+
 resource "helm_release" "grafana" {
   name       = "grafana"
   repository = "https://grafana.github.io/helm-charts"


### PR DESCRIPTION
without defining kuberenetes_namespace resource, we get this error:
Error: namespaces "monitoring" not found

I tried with terraform 1.5.4 and helm 3.12.2.

also I created an issue for deprecated PodSecurity Policies 
https://github.com/grafana/helm-charts/issues/2557